### PR TITLE
Add `withings_current_hydration` metric

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -5,10 +5,18 @@ import "github.com/prometheus/client_golang/prometheus"
 var currentWeightMetric = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Name: "withings_current_weight",
-		Help: "Shows the latest weight measurement (assumed in kg)",
+		Help: "Shows the latest weight measurement (in kg)",
+	},
+)
+
+var hydrationMetric = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "withings_current_hydration",
+		Help: "Shows the latest hydration measurement (in kg)",
 	},
 )
 
 func registerMetrics() {
 	prometheus.MustRegister(currentWeightMetric)
+	prometheus.MustRegister(hydrationMetric)
 }


### PR DESCRIPTION
- The Body+ smart scales take [many measurements](https://developer.withings.com/oauth2/#operation/measure-getmeas).
- This adds another one to this exporter: hydration levels. I don't know how it works them out - that's one to research later!
- There's probably a more pleasing way of fetching all the metrics at the same time (some kind of loop, etc.), but that can wait until daylight hours some other day.