### PR TITLE
Add a basic docker file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:sid-slim
+ADD . /code
+RUN apt update && apt install -y ca-certificates golang-go golang-github-prometheus-client-golang-dev && cd /code && go build .
+CMD /code/withings-exporter


### PR DESCRIPTION
This adds a simple docker file for withings-exporter. I figured I'd share it, but have no idea whether you're up for maintaining a docker file - so feel free to just close this. The docker file seems to work, though it is a little bit tricky to do the interactive thing with the response code if you're e.g. running it in kubernetes.